### PR TITLE
hotfix: version control and .jar release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Publish Release
         uses: softprops/action-gh-release@v2
         with:
-          files: target/*.jar
+          files: "target/**.jar"
           name: ${{ env.VERSION }}
           tag_name: ${{ env.VERSION }}

--- a/JabberPointSQ/pom.xml
+++ b/JabberPointSQ/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.nhlstenden.jabberpoint</groupId>
   <artifactId>jabbersq</artifactId>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <name>JabberPointSQ</name>
 
   <properties>


### PR DESCRIPTION
Something went wrong while setting up GitHub workflows, the version semantics were broken.